### PR TITLE
Add code coverage tracking using SimpleCov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/bundle/
 
 # rspec failure tracking
 .rspec_status

--- a/nacha.gemspec
+++ b/nacha.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency 'rubocop-performance'
   spec.add_development_dependency 'rubocop-rspec'
+  spec.add_development_dependency 'simplecov'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 require 'bundler/setup'
 require 'fileutils'
 require 'nacha'


### PR DESCRIPTION
This commit introduces SimpleCov to your project to track code coverage.

The following changes were made:
- Added `simplecov` as a development dependency to `nacha.gemspec`.
- Configured SimpleCov in `spec/spec_helper.rb` to start before tests run.
- Ensured that the `coverage` directory (where reports are stored) is ignored by Git.
- Ran tests to confirm that coverage reports are generated successfully.

Thanks Jules